### PR TITLE
Added conditional open arguments based on the Python version

### DIFF
--- a/new_project.py
+++ b/new_project.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import argparse
 import os
+import sys
 from datetime import datetime
 
 from jinja2 import Environment, FileSystemLoader
@@ -121,7 +122,12 @@ class ProjectSetup(object):
                             filename=filename
                         )
 
-                        with open(new_path, 'wb') as new_file:
+                        if sys.version_info[0] < 3:
+                            write_args = 'wb'
+                        else:
+                            write_args = 'w'
+
+                        with open(new_path, write_args) as new_file:
                             new_file.write(template.render(context))
                             new_file.write("\n")
 


### PR DESCRIPTION
### Purpose

Writing out a Jinja2 template would break when 'wb' is used in Python 3.5.2

### Caveats
I assume this has to do with some string changes from Python 2.X to Python 3.x.  I don't have a deep understanding of the issue, but this fixed it for me.

### Testing
I've ran this modified `new_project.py` script with Python 2.7.10 and Python 3.5.2 and it generates the projects in both cases.